### PR TITLE
chore: Use docker authenticated pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,4 +14,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - compile
+      - compile:
+          context:
+            - docker-hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   compile:
     docker:
       - image: gcc:latest
+        auth:
+              username: $DOCKERHUB_USERNAME
+              password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run: cd lib && make -j $(nproc) all


### PR DESCRIPTION
Docker Hub will begin limiting anonymous image pulls on November 1st.