### PR TITLE
Add ~/.cache to the CI cache config to store a bazel binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - save_cache:
           key: bazel
           paths:
+            - ~/.cache
             - lib/bazel-bin
             - lib/bazel-lib
             - lib/bazel-out
@@ -41,6 +42,7 @@ jobs:
       - save_cache:
           key: bazel
           paths:
+            - ~/.cache
             - lib/bazel-bin
             - lib/bazel-lib
             - lib/bazel-out
@@ -59,6 +61,7 @@ jobs:
       - save_cache:
           key: bazel
           paths:
+            - ~/.cache
             - lib/bazel-bin
             - lib/bazel-lib
             - lib/bazel-out


### PR DESCRIPTION
Add ~/.cache to the CI cache config to store a bazel binary