### PR TITLE
extgcd takes int64_t instead of uint64_t

### DIFF
--- a/aoj/NTL/NTL1E/main-iterative.cpp
+++ b/aoj/NTL/NTL1E/main-iterative.cpp
@@ -1,19 +1,19 @@
 #include <bits/stdc++.h>
 
-inline uint64_t extgcd(
-    uint64_t const a,
-    uint64_t const b,
+inline int64_t extgcd(
+    int64_t const a,
+    int64_t const b,
     int64_t &x,
     int64_t &y
 )
 {
     x = 1, y = 0;
     int64_t x1 = 0, y1 = 1;
-    uint64_t a1 = a, b1 = b;
+    int64_t a1 = a, b1 = b;
     // a * x  + b * y  = a1
     // a * x1 + b * y1 = b1
     while (b1 > 0) {
-        uint64_t q = a1 / b1;
+        int64_t q = a1 / b1;
         std::tie(x, x1) = std::make_tuple(x1, x - q * x1);
         std::tie(y, y1) = std::make_tuple(y1, y - q * y1);
         std::tie(a1, b1) = std::make_tuple(b1, a1 - q * b1);

--- a/aoj/NTL/NTL1E/main-recursive.cpp
+++ b/aoj/NTL/NTL1E/main-recursive.cpp
@@ -1,8 +1,8 @@
 #include <bits/stdc++.h>
 
-inline uint64_t extgcd(
-    uint64_t const a,
-    uint64_t const b,
+inline int64_t extgcd(
+    int64_t const a,
+    int64_t const b,
     int64_t &x, int64_t &y
 )
 {
@@ -11,7 +11,7 @@ inline uint64_t extgcd(
         return a;
     }
     int64_t x1, y1;
-    uint64_t g = extgcd(b, a % b, x1, y1);
+    int64_t g = extgcd(b, a % b, x1, y1);
     x = y1;
     y = x1 - y1 * (a / b);
     return g;

--- a/lib/cpalgo/algebra/extgcd_iterative.hpp
+++ b/lib/cpalgo/algebra/extgcd_iterative.hpp
@@ -14,20 +14,20 @@
 // Verified:
 //  - https://onlinejudge.u-aizu.ac.jp/courses/library/6/NTL/1/NTL_1_E
 //
-inline uint64_t extgcd(
-    uint64_t const a,
-    uint64_t const b,
+inline int64_t extgcd(
+    int64_t const a,
+    int64_t const b,
     int64_t &x,
     int64_t &y
 )
 {
     x = 1, y = 0;
     int64_t x1 = 0, y1 = 1;
-    uint64_t a1 = a, b1 = b;
+    int64_t a1 = a, b1 = b;
     // a * x  + b * y  = a1
     // a * x1 + b * y1 = b1
     while (b1 > 0) {
-        uint64_t q = a1 / b1;
+        int64_t q = a1 / b1;
         std::tie(x, x1) = std::make_tuple(x1, x - q * x1);
         std::tie(y, y1) = std::make_tuple(y1, y - q * y1);
         std::tie(a1, b1) = std::make_tuple(b1, a1 - q * b1);

--- a/lib/cpalgo/algebra/extgcd_recursive.hpp
+++ b/lib/cpalgo/algebra/extgcd_recursive.hpp
@@ -22,9 +22,9 @@
 // Verified:
 //  - https://onlinejudge.u-aizu.ac.jp/courses/library/6/NTL/1/NTL_1_E
 //
-inline uint64_t extgcd(
-    uint64_t const a,
-    uint64_t const b,
+inline int64_t extgcd(
+    int64_t const a,
+    int64_t const b,
     int64_t &x, int64_t &y
 )
 {
@@ -33,7 +33,7 @@ inline uint64_t extgcd(
         return a;
     }
     int64_t x1, y1;
-    uint64_t g = extgcd(b, a % b, x1, y1);
+    int64_t g = extgcd(b, a % b, x1, y1);
     x = y1;
     y = x1 - y1 * (a / b);
     return g;

--- a/lib/main/algebra/extgcd/template-extgcd-interop.hpp
+++ b/lib/main/algebra/extgcd/template-extgcd-interop.hpp
@@ -3,7 +3,7 @@
 #include <bits/stdc++.h>
 #include "template/template-main.hpp"
 
-void action_extgcd(std::function<uint64_t(uint64_t, uint64_t, int64_t&, int64_t&)> const& extgcd) {
+void action_extgcd(std::function<uint64_t(int64_t, int64_t, int64_t&, int64_t&)> const& extgcd) {
     int64_t a, b, x, y, g;
     std::cin >> a >> b;
 
@@ -16,7 +16,7 @@ void action_extgcd(std::function<uint64_t(uint64_t, uint64_t, int64_t&, int64_t&
 void setup(
     std::string& header,
     std::map<std::string,Command>& commands,
-    std::function<uint64_t(uint64_t, uint64_t, int64_t&, int64_t&)> const& extgcd
+    std::function<uint64_t(int64_t, int64_t, int64_t&, int64_t&)> const& extgcd
 ) {
     commands["extgcd"] =
         Command { "extgcd {a} {b}", std::bind(action_extgcd, extgcd) };


### PR DESCRIPTION
To prevent overflow